### PR TITLE
修正部分错误？

### DIFF
--- a/Docker/start.sh
+++ b/Docker/start.sh
@@ -16,9 +16,9 @@ print_message() {
 # 脚本开始
 print_message "$YELLOW" "=== Yunzai 初始化脚本开始 ==="
 
-# 步骤 1: 启动 Redis 服务器
+# 步骤 1: 启动 Redis 服务器并指定配置文件
 print_message "$GREEN" "步骤 1: 启动 Redis 服务器"
-redis-server --daemonize yes &> /dev/null
+redis-server /etc/redis/redis.conf --daemonize yes &> /dev/null
 print_message "$GREEN" "Redis 服务器已启动"
 
 # 步骤 2: 检查并初始化 Yunzai
@@ -43,7 +43,7 @@ if [ -z "$(ls -A /Yunzai)" ]; then
     print_message "$YELLOW" "安装 Node.js 依赖..."
     npm --registry=https://registry.npmmirror.com install pnpm -g
     pnpm config set registry https://registry.npmmirror.com
-    pnpm install -P
+    pnpm install -P --no-interactive
     print_message "$GREEN" "Node.js 依赖安装完成"
 
     print_message "$YELLOW" "安装全局 Freyr 工具..."
@@ -77,7 +77,7 @@ else
 
     # 更新依赖
     print_message "$YELLOW" "更新 Node.js 依赖..."
-    pnpm install -P
+    pnpm install -P --no-interactive
     print_message "$GREEN" "Node.js 依赖更新完成"
 
 fi


### PR DESCRIPTION
佬，你的脚本自启好像有点问题😭
一个是重启的时候卡在这里了，导致yunzai无法自动启动
```log
=== Yunzai 初始化脚本开始 ===

步骤 1: 启动 Redis 服务器

Redis 服务器已启动

步骤 2: 检查 Yunzai 目录

Yunzai 目录不为空，跳过初始化步骤

更新 Node.js 依赖...

Scope: all 12 workspace projects

? The modules directories will be removed and reinstalled from scratch. Proceed? (Y/n) ‣ true
```
然后我在启动脚本pnpm install -P后面加了`--no-interactive`来完全禁用交互提示解决了这个问题
然后就是redis更坑了他一直不能触发 RDB 保存，我折腾半天`/etc/redis/redis.conf`一直不行，然后去Redis 命令行客户端看配置文件结果
```log
127.0.0.1:6379> CONFIG GET save
1) "save"
2) ""
127.0.0.1:6379>
```
居然获取到的配置没配置save规则😨，合着我改了半天他用的就不是那个配置文件，我在启动脚本里指定了配置文件，现在又好了
不知道这么改有没有问题，还请大佬看看
还有一个小建议，就是构建镜像的时候能不能顺便把emoji字体带上，不然emoji渲染不出来，还要后来自己装